### PR TITLE
docs(readme): add systemd service management commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,44 @@ This repository was created to **automate and streamline the reel-creation workf
 
 ---
 
+## Easy Startup Commands
+
+For easy start and managing components, we have created systemd services for Linux / Ubuntu / Debian.
+
+Please check folder named **systemd_scripts** for systemd scripts for following four services.
+
+### Reel Quick Backend
+
+```bash
+sudo systemctl start reel-quick-backend
+sudo systemctl restart reel-quick-backend
+systemctl status reel-quick-backend
+```
+
+### Reel Quick Frontend
+
+```bash
+sudo systemctl start reel-quick-frontend
+sudo systemctl restart reel-quick-frontend
+systemctl status reel-quick-frontend
+```
+
+### Reel Quick Video Worker
+
+```bash
+sudo systemctl start reel-quick-video-worker
+sudo systemctl restart reel-quick-video-worker
+systemctl status reel-quick-video-worker
+```
+
+### Reel Quick Text Overlay Worker
+
+```bash
+sudo systemctl start reel-quick-text-overlay-worker
+sudo systemctl restart reel-quick-text-overlay-worker
+systemctl status reel-quick-text-overlay-worker
+```
+
 ## Prerequisite Software Installation
 
 ### Backend Installation

--- a/systemd_scripts/reel-quick-backend.service
+++ b/systemd_scripts/reel-quick-backend.service
@@ -1,0 +1,18 @@
+# /etc/systemd/system/reel-quick-backend.service
+
+[Unit]
+Description=Reel Quick FastAPI Backend
+After=network.target
+
+[Service]
+Type=simple
+User=ronin1770
+WorkingDirectory=/usr/local/development/reel-quick/reel-quick
+Environment="PATH=/usr/local/development/reel-quick/ig_venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin"
+ExecStart=/usr/local/development/reel-quick/ig_venv/bin/uvicorn backend.main:app --host 0.0.0.0 --port 8000
+
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd_scripts/reel-quick-frontend.service
+++ b/systemd_scripts/reel-quick-frontend.service
@@ -1,0 +1,18 @@
+# /etc/systemd/system/reel-quick-frontend.service
+
+[Unit]
+Description=Reel Quick Next.js Frontend
+After=network.target reel-quick-backend.service
+
+[Service]
+Type=simple
+User=ronin1770
+WorkingDirectory=/usr/local/development/reel-quick/frontend
+
+ExecStart=/usr/bin/npm run dev
+
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd_scripts/reel-quick-text-overlay-worker.service
+++ b/systemd_scripts/reel-quick-text-overlay-worker.service
@@ -1,0 +1,19 @@
+# /etc/systemd/system/reel-quick-text-overlay-worker.service
+
+[Unit]
+Description=Reel Quick Text Overlay ARQ Worker
+After=network.target reel-quick-backend.service
+
+[Service]
+Type=simple
+User=ronin1770
+WorkingDirectory=/usr/local/development/reel-quick/reel-quick
+Environment="PATH=/usr/local/development/reel-quick/ig_venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin"
+
+ExecStart=/usr/local/development/reel-quick/ig_venv/bin/arq backend.workers.text_overlay_worker.WorkerSettings
+
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd_scripts/reel-quick-video-worker.service
+++ b/systemd_scripts/reel-quick-video-worker.service
@@ -1,0 +1,19 @@
+# /etc/systemd/system/reel-quick-video-worker.service
+
+[Unit]
+Description=Reel Quick Video Maker ARQ Worker
+After=network.target reel-quick-backend.service
+
+[Service]
+Type=simple
+User=ronin1770
+WorkingDirectory=/usr/local/development/reel-quick/reel-quick
+Environment="PATH=/usr/local/development/reel-quick/ig_venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin"
+
+ExecStart=/usr/local/development/reel-quick/ig_venv/bin/arq backend.workers.video_maker.WorkerSettings
+
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Add a quick-start section for Linux/Ubuntu/Debian users showing how to start, restart, and check status for the backend, frontend, video worker, and text overlay worker.

Refs: feat#23

Tested. OK to market